### PR TITLE
workaround GTK bug on wayland

### DIFF
--- a/gtetrinet.desktop.in
+++ b/gtetrinet.desktop.in
@@ -2,7 +2,7 @@
 Name=GTetrinet
 GenericName=Tetrinet client
 Comment=Tetrinet client for GNOME
-Exec=gtetrinet
+Exec=env GDK_BACKEND=x11 gtetrinet
 Icon=gtetrinet.png
 StartupNotify=true
 Terminal=false


### PR DESCRIPTION
unfortunately the game is unplayable on wayland (gnome-shell), blocks simply does not appears :/
so for now the workaround is to force the game to start within X11
(the title "gtk bug" is maybe misleading, i have absolutely no clue where the bug is)